### PR TITLE
Feature/role based flocking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = src/obstacle_detector_2
 	url = https://github.com/giuschio/obstacle_detector_2.git
 	branch = humble-devel
+[submodule "src/physics_simulators/Gazebo/px4_msgs"]
+	path = src/physics_simulators/Gazebo/px4_msgs
+	url = https://github.com/PX4/px4_msgs

--- a/src/config/config_minidancers_default.yaml
+++ b/src/config/config_minidancers_default.yaml
@@ -89,7 +89,6 @@ VAT_mission_flocking_parameters:
   auto_propulsion_flag: false
   secondary_objective_flag: true
 
-
 VAT_potential_flocking_parameters:
   v_flock: 0.5
   v_max: 3

--- a/src/config/config_minidancers_default.yaml
+++ b/src/config/config_minidancers_default.yaml
@@ -10,7 +10,7 @@ seed: 15
 # ******* SCENARIO DEFINITION *******
 
 # The number of robots in the fleet
-robots_number: 8
+robots_number: 10
 
 # The model of the robot. Must match the robots names in Gazebo in the following way : {robots_model}_{i} where i = 0..{robots_number}
 # Example : x500_0, x500_1, x500_2, etc.
@@ -50,9 +50,14 @@ broadcast_flow:
   flow_id: 2
 
 # ******* FLOCKING *******
+# **** Constraints ****
+expected_deconnexion_distance: 50.0
+
+# **** Parameters ****
 VAT_undefined_flocking_parameters:
   v_flock: 0.5
   v_max: 3
+  v_sec_max: 3
   a_frict: 4.16
   p_frict: 3.2
   r_0_frict: 85.3
@@ -68,37 +73,43 @@ VAT_undefined_flocking_parameters:
   v_shill: 13.622
   auto_propulsion_flag: false
   secondary_objective_flag: true
+  # If use_deconnexion_distance_instead_of_p_att is true, p_att will be overriden so that the 
+  # attraction speed can counter the v_sec_max at the expected_deconnexion_distance.
+  use_deconnexion_distance_instead_of_p_att: false 
 
 
 VAT_mission_flocking_parameters:
-  v_flock: 0.5
-  v_max: 3
+  v_flock: 1.0
+  v_max: 30
+  v_sec_max: 30
   a_frict: 4.16
   p_frict: 3.2
   r_0_frict: 85.3
   C_frict: 0.8
   v_frict: 0.63
   p_att: 0.08  # old 0.08
-  r_0_att: 25
+  r_0_att: 40
   p_rep: 0.13
-  r_0_rep: 20
+  r_0_rep: 30
   a_shill: 53
   p_shill: 3.55
   r_0_shill: 0.3 # old 0.3
   v_shill: 13.622
   auto_propulsion_flag: false
   secondary_objective_flag: true
+  use_deconnexion_distance_instead_of_p_att: true
 
 VAT_potential_flocking_parameters:
   v_flock: 0.5
   v_max: 3
+  v_sec_max: 3
   a_frict: 4.16
   p_frict: 3.2
   r_0_frict: 85.3
   C_frict: 0.8
   v_frict: 0.63
-  p_att: 0.08  # old 0.08
-  r_0_att: 25
+  p_att: 0.16  # old 0.08
+  r_0_att: 30
   p_rep: 0.13
   r_0_rep: 20
   a_shill: 53
@@ -107,10 +118,12 @@ VAT_potential_flocking_parameters:
   v_shill: 13.622
   auto_propulsion_flag: false
   secondary_objective_flag: true
+  use_deconnexion_distance_instead_of_p_att: false
 
 VAT_idle_flocking_parameters:
   v_flock: 0.5
   v_max: 3
+  v_sec_max: 3
   a_frict: 4.16
   p_frict: 3.2
   r_0_frict: 85.3
@@ -126,6 +139,7 @@ VAT_idle_flocking_parameters:
   v_shill: 13.622
   auto_propulsion_flag: false
   secondary_objective_flag: true
+  use_deconnexion_distance_instead_of_p_att: false
 
 # ******* PRE-PLANNED FLIGHT *******
 circle_parameters:

--- a/src/config/config_minidancers_default.yaml
+++ b/src/config/config_minidancers_default.yaml
@@ -50,6 +50,9 @@ broadcast_flow:
   flow_id: 2
 
 # ******* FLOCKING *******
+# Indicates if the ROS flocking_controller should publish on a topic the command its sends.
+controller_publish_cmd: true
+
 # **** Constraints ****
 expected_deconnexion_distance: 50.0
 

--- a/src/config/config_minidancers_default.yaml
+++ b/src/config/config_minidancers_default.yaml
@@ -50,7 +50,7 @@ broadcast_flow:
   flow_id: 2
 
 # ******* FLOCKING *******
-VAT_idle_flocking_parameters:
+VAT_undefined_flocking_parameters:
   v_flock: 0.5
   v_max: 3
   a_frict: 4.16
@@ -59,7 +59,7 @@ VAT_idle_flocking_parameters:
   C_frict: 0.8
   v_frict: 0.63
   p_att: 0.08  # old 0.08
-  r_0_att: 20
+  r_0_att: 25
   p_rep: 0.13
   r_0_rep: 20
   a_shill: 53
@@ -68,6 +68,7 @@ VAT_idle_flocking_parameters:
   v_shill: 13.622
   auto_propulsion_flag: false
   secondary_objective_flag: true
+
 
 VAT_mission_flocking_parameters:
   v_flock: 0.5
@@ -79,6 +80,45 @@ VAT_mission_flocking_parameters:
   v_frict: 0.63
   p_att: 0.08  # old 0.08
   r_0_att: 25
+  p_rep: 0.13
+  r_0_rep: 20
+  a_shill: 53
+  p_shill: 3.55
+  r_0_shill: 0.3 # old 0.3
+  v_shill: 13.622
+  auto_propulsion_flag: false
+  secondary_objective_flag: true
+
+
+VAT_potential_flocking_parameters:
+  v_flock: 0.5
+  v_max: 3
+  a_frict: 4.16
+  p_frict: 3.2
+  r_0_frict: 85.3
+  C_frict: 0.8
+  v_frict: 0.63
+  p_att: 0.08  # old 0.08
+  r_0_att: 25
+  p_rep: 0.13
+  r_0_rep: 20
+  a_shill: 53
+  p_shill: 3.55
+  r_0_shill: 0.3 # old 0.3
+  v_shill: 13.622
+  auto_propulsion_flag: false
+  secondary_objective_flag: true
+
+VAT_idle_flocking_parameters:
+  v_flock: 0.5
+  v_max: 3
+  a_frict: 4.16
+  p_frict: 3.2
+  r_0_frict: 85.3
+  C_frict: 0.8
+  v_frict: 0.63
+  p_att: 0.08  # old 0.08
+  r_0_att: 20
   p_rep: 0.13
   r_0_rep: 20
   a_shill: 53

--- a/src/dancers_msgs/msg/AgentStruct.msg
+++ b/src/dancers_msgs/msg/AgentStruct.msg
@@ -4,7 +4,7 @@ uint8 AGENT_ROLE_POTENTIAL=2
 uint8 AGENT_ROLE_IDLE=3
 
 uint8 agent_role
-uint8 agent_id
+uint32 agent_id
 dancers_msgs/AgentState state
 
 dancers_msgs/NeighborArray neighbor_array

--- a/src/dancers_msgs/msg/Neighbor.msg
+++ b/src/dancers_msgs/msg/Neighbor.msg
@@ -1,0 +1,3 @@
+# This message assumes that the position and the role of the neighbor can be found purely by knowing the agent_id. 
+uint32 agent_id
+float64 link_quality

--- a/src/dancers_msgs/msg/NeighborArray.msg
+++ b/src/dancers_msgs/msg/NeighborArray.msg
@@ -1,1 +1,1 @@
-int32[] neighbors
+dancers_msgs/Neighbor[] neighbors

--- a/src/dancers_msgs/msg/NeighborIdQuality.msg
+++ b/src/dancers_msgs/msg/NeighborIdQuality.msg
@@ -1,2 +1,0 @@
-uint32 id
-float64 link_quality

--- a/src/dancers_msgs/msg/NeighborIdQualityArray.msg
+++ b/src/dancers_msgs/msg/NeighborIdQualityArray.msg
@@ -1,1 +1,0 @@
-dancers_msgs/NeighborIdQuality[] neighbors_id_quality_array

--- a/src/network_simulators/ns-3_sim/CMakeLists.txt
+++ b/src/network_simulators/ns-3_sim/CMakeLists.txt
@@ -45,38 +45,38 @@ find_package(yaml-cpp REQUIRED)
 #   protobuf_msgs
 #   rclcpp)
 
-add_executable(adhoc_chain_flocking src/adhoc_chain_flocking.cpp 
-  include/${PROJECT_NAME}/wifi-application.cpp 
-  include/${PROJECT_NAME}/wifi-application.h
-  include/${PROJECT_NAME}/chain-flocking-application.cpp
-  include/${PROJECT_NAME}/chain-flocking-application.h
-  include/${PROJECT_NAME}/pick-neighbors-header.cpp
-  include/${PROJECT_NAME}/pick-neighbors-header.h
-  include/${PROJECT_NAME}/flocking-application.cpp
-  include/${PROJECT_NAME}/flocking-application.h
-  )
-target_link_libraries(adhoc_chain_flocking
-  yaml-cpp
-  ns3::libcore
-  ns3::libwifi
-  ns3::libmobility
-  ns3::libolsr
-  ns3::libaodv
-  ns3::libdsdv
-  ns3::libdsr
-  ns3::libinternet
-  ns3::libbuildings
-  ns3::libpropagation
-  ns3::libspectrum
-  ns3::libnetwork
-  ns3::libapplications
-  ns3::libcsma
-  ns3::libtap-bridge
-  ns3::libbatmand)
-ament_target_dependencies(adhoc_chain_flocking
-  Boost 
-  protobuf_msgs
-  rclcpp)
+# add_executable(adhoc_chain_flocking src/adhoc_chain_flocking.cpp 
+#   include/${PROJECT_NAME}/wifi-application.cpp 
+#   include/${PROJECT_NAME}/wifi-application.h
+#   include/${PROJECT_NAME}/chain-flocking-application.cpp
+#   include/${PROJECT_NAME}/chain-flocking-application.h
+#   include/${PROJECT_NAME}/pick-neighbors-header.cpp
+#   include/${PROJECT_NAME}/pick-neighbors-header.h
+#   include/${PROJECT_NAME}/flocking-application.cpp
+#   include/${PROJECT_NAME}/flocking-application.h
+#   )
+# target_link_libraries(adhoc_chain_flocking
+#   yaml-cpp
+#   ns3::libcore
+#   ns3::libwifi
+#   ns3::libmobility
+#   ns3::libolsr
+#   ns3::libaodv
+#   ns3::libdsdv
+#   ns3::libdsr
+#   ns3::libinternet
+#   ns3::libbuildings
+#   ns3::libpropagation
+#   ns3::libspectrum
+#   ns3::libnetwork
+#   ns3::libapplications
+#   ns3::libcsma
+#   ns3::libtap-bridge
+#   ns3::libbatmand)
+# ament_target_dependencies(adhoc_chain_flocking
+#   Boost 
+#   protobuf_msgs
+#   rclcpp)
 
 add_executable(fake_neighborhood src/fake_neighborhood.cpp
   include/${PROJECT_NAME}/wifi-application.cpp 
@@ -198,7 +198,7 @@ INSTALL(
   # ns-3_only_ap
   # ns-3_only_csma
   # ns-3_sim_wifi_adhoc
-  adhoc_chain_flocking
+  # adhoc_chain_flocking
   fake_neighborhood
   # packet_success_exp
   # carousel-use-case

--- a/src/network_simulators/ns-3_sim/src/fake_neighborhood.cpp
+++ b/src/network_simulators/ns-3_sim/src/fake_neighborhood.cpp
@@ -334,7 +334,10 @@ public:
         Config::Set(
             "/NodeList/*/DeviceList/*/$ns3::WifiNetDevice/HtConfiguration/ShortGuardIntervalSupported",
             BooleanValue(true));
-
+        // Fix non-unicast data rate to be the same as that of unicast
+        Config::SetDefault ("ns3::WifiRemoteStationManager::NonUnicastMode",
+            StringValue (phyMode));
+            
         RCLCPP_DEBUG(this->get_logger(), "Finished the configuration of WIFI module");
 
         /* **************** IP / ROUTING MODULE **************** */

--- a/src/network_simulators/ns-3_sim/src/fake_neighborhood.cpp
+++ b/src/network_simulators/ns-3_sim/src/fake_neighborhood.cpp
@@ -722,8 +722,9 @@ public:
                         path.pop();
                         int neighbor = path.top();
                         double distance = this->nodes.Get(curr)->GetObject<MobilityModel>()->GetDistanceFrom(this->nodes.Get(neighbor)->GetObject<MobilityModel>());
-                        this->mission_neighbors[curr][neighbor] = std::make_pair(distance, Simulator::Now());
-                        this->mission_neighbors[neighbor][curr] = std::make_pair(distance, Simulator::Now());
+                        
+                        this->mission_neighbors[curr][neighbor] = std::make_pair(this->pathlosses[curr][neighbor], Simulator::Now());
+                        this->mission_neighbors[neighbor][curr] = std::make_pair(this->pathlosses[neighbor][curr], Simulator::Now());
                         // std::cout << " -> " << neighbor ;
                         curr = neighbor;
                     }
@@ -1029,7 +1030,7 @@ FakeNeighborhood::generate_neighbors_msg()
         }
     }
 
-    // std::cout << ordered_neighbors_msg->DebugString() << std::endl;
+    std::cout << ordered_neighbors_msg.DebugString() << std::endl;
 
     std::string str_response;
     ordered_neighbors_msg.SerializeToString(&str_response);

--- a/src/physics_simulators/MiniDancers/flocking_controller/include/flocking_controller/agent_util.hpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/include/flocking_controller/agent_util.hpp
@@ -21,6 +21,15 @@ namespace agent_util
     };
 
     /**
+     * @brief Structure containing the information about the neighbors.
+     */
+    struct NeighborInfo_t
+    {
+        int id;
+        float link_quality;
+    };
+
+    /**
      * @brief Structure of all states of an agent at a given time.
      */
     struct AgentState_t 
@@ -30,8 +39,9 @@ namespace agent_util
         
         Eigen::Vector3d position;
         Eigen::Vector3d velocity;
-    };
 
+        std::vector<NeighborInfo_t> neighbors;
+    };
 
     /**
      * @brief Returns an AgentState_t object based on an agent_struct ROS message.
@@ -51,6 +61,28 @@ namespace agent_util
         {
             agent_state.role_type = AgentRoleType::Mission;
         }
+        else if(agent_struct.agent_role == agent_struct.AGENT_ROLE_POTENTIAL)
+        {
+            agent_state.role_type = AgentRoleType::Potential;
+        }
+        else if(agent_struct.agent_role == agent_struct.AGENT_ROLE_UNDEFINED)
+        {
+            agent_state.role_type = AgentRoleType::Undefined;
+        }
+        else
+        {
+            // Add logging
+            agent_state.role_type = AgentRoleType::Undefined;
+        }
+
+        for(auto& neighbor_msg : agent_struct.neighbor_array.neighbors)
+        {
+            NeighborInfo_t neighbor_info;
+            neighbor_info.id = neighbor_msg.agent_id;
+            neighbor_info.link_quality = neighbor_msg.link_quality;
+
+            agent_state.neighbors.push_back(neighbor_info);
+        }
 
         agent_state.position[0] = agent_struct.state.position.x;
         agent_state.position[1] = agent_struct.state.position.y;
@@ -59,7 +91,7 @@ namespace agent_util
         agent_state.velocity[0] = agent_struct.state.velocity_heading.velocity.x;
         agent_state.velocity[1] = agent_struct.state.velocity_heading.velocity.y;
         agent_state.velocity[2] = agent_struct.state.velocity_heading.velocity.z;
-        
+
         return agent_state; 
     }
 }

--- a/src/physics_simulators/MiniDancers/flocking_controller/package.xml
+++ b/src/physics_simulators/MiniDancers/flocking_controller/package.xml
@@ -12,7 +12,6 @@
   <depend>rclcpp</depend>
   <depend>dancers_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>mini_dancers</depend>
   
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
@@ -24,44 +24,44 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     std::vector<std::shared_ptr<const agent_util::AgentState_t>> potential_neighbors;
     std::vector<std::shared_ptr<const agent_util::AgentState_t>> idle_neighbors;
 
-    std::cout<<"Current agent ID: " << id_ << std::endl;
+    //std::cout<<"Current agent ID: " << id_ << std::endl;
     for (auto neighbor : self_agent.neighbors)
     {
         if (neighbor.id != id_)
         {
             const agent_util::AgentState_t& neighbor_agent = *agent_list[neighbor.id];
 
-            std::cout<<"Nieghbor Id: " << neighbor.id << ". Link quality: "<< neighbor.link_quality;
+            //std::cout<<"Nieghbor Id: " << neighbor.id << ". Link quality: "<< neighbor.link_quality;
             if( neighbor_agent.role_type == agent_util::AgentRoleType::Undefined)
             {
                 //Should not happen by definition of the Undefined role
-                std::cout << "Agent of id " << id_ << " has an neighbor of id" << neighbor.id << " that has an undefined role. It shouldn't happen."<<std::endl;
+                //std::cout << "Agent of id " << id_ << " has an neighbor of id" << neighbor.id << " that has an undefined role. It shouldn't happen."<<std::endl;
             }
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Mission)
             {
                 mission_neighbors.push_back(agent_list[neighbor.id]);
-                std::cout<<" Role: Mission"<<std::endl;
+                //std::cout<<" Role: Mission"<<std::endl;
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Mission"<<std::endl;
+                    //std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Mission"<<std::endl;
                 }
             }
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Potential)
             {
                 potential_neighbors.push_back(agent_list[neighbor.id]);
-                std::cout<<" Role: Potential"<<std::endl;
+                //std::cout<<" Role: Potential"<<std::endl;
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Potential"<<std::endl;
+                    //std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Potential"<<std::endl;
                 }
             }
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Idle)
             {
-                std::cout<<" Role: Idle"<<std::endl;
+                //std::cout<<" Role: Idle"<<std::endl;
                 idle_neighbors.push_back(agent_list[neighbor.id]);
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Idle"<<std::endl;
+                    //std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Idle"<<std::endl;
                 }
             }
         }
@@ -72,14 +72,14 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
         // TODO: Find behavior for undefined roles
         if (id_ == DEBUG_ID_TO_LOG)
         {
-            std::cout<<"Self role: Undefined"<<std::endl;
+            //std::cout<<"Self role: Undefined"<<std::endl;
         }
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Mission)
     {     
         if (id_ == DEBUG_ID_TO_LOG)
         {
-            std::cout<<"Self role: Mission"<<std::endl;
+            //std::cout<<"Self role: Mission"<<std::endl;
         }
         // Only interacts with mission neihbors
         summed_velocity += alignmentTerm(self_agent, mission_neighbors, VAT_params_[self_agent.role_type])
@@ -90,7 +90,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     {
         if (id_ == DEBUG_ID_TO_LOG)
         {
-            std::cout<<"Self role: Potential"<<std::endl;
+            //std::cout<<"Self role: Potential"<<std::endl;
         }
         // Attracted to at most the two best (based on linked quality) mission neighbor and repulsed by other mission
         std::vector<std::shared_ptr<const agent_util::AgentState_t>> two_best_mission_neighbors;
@@ -98,14 +98,14 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
         if (mission_neighbors.size()==1)
         {
             two_best_mission_neighbors.push_back(mission_neighbors[0]);
-            std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
+            //std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
         }
         else if (mission_neighbors.size() >= 2)
         {
             two_best_mission_neighbors.push_back(mission_neighbors[0]);
             two_best_mission_neighbors.push_back(mission_neighbors[1]);
-            std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
-            std::cout<<"Has neighbor "<< mission_neighbors[1]->id <<" as " <<" best Mission"<<std::endl;
+            //std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
+            //std::cout<<"Has neighbor "<< mission_neighbors[1]->id <<" as " <<" best Mission"<<std::endl;
 
             for (int index = 2; index < mission_neighbors.size(); index++)
             {
@@ -129,7 +129,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     {
         if (id_ == DEBUG_ID_TO_LOG)
         {
-            std::cout<<"Self role: Idle"<<std::endl;
+            //std::cout<<"Self role: Idle"<<std::endl;
         }
         // Interacts normally with idle neighbors.
         summed_velocity += alignmentTerm(self_agent, idle_neighbors, VAT_params_[self_agent.role_type])
@@ -143,7 +143,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     }
     else
     {
-        std::cout<<"Error: Agent has an undefined role. The role as a casted int value of "<< self_agent.role_type << ". Returning a velocity of 0."<<std::endl;
+        //std::cout<<"Error: Agent has an undefined role. The role as a casted int value of "<< self_agent.role_type << ". Returning a velocity of 0."<<std::endl;
         return velocity_heading;
     }
 
@@ -270,9 +270,9 @@ Eigen::Vector3d VATController::secondaryObjective(const agent_util::AgentState_t
 
     result += role_params.v_flock * -(relative_position);
 
-    if (result.norm() > role_params.v_max)
+    if (result.norm() > role_params.v_sec_max)
     {
-        result = role_params.v_max * result.normalized();
+        result = role_params.v_sec_max * result.normalized();
     }
 
     return result;

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
@@ -31,7 +31,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
         {
             const agent_util::AgentState_t& neighbor_agent = *agent_list[neighbor.id];
 
-            std::cout<<"Nieghbor Id: " << neighbor.id << ". Link quality: "<< neighbor.link_quality <<std::endl;
+            std::cout<<"Nieghbor Id: " << neighbor.id << ". Link quality: "<< neighbor.link_quality;
             if( neighbor_agent.role_type == agent_util::AgentRoleType::Undefined)
             {
                 //Should not happen by definition of the Undefined role
@@ -40,6 +40,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Mission)
             {
                 mission_neighbors.push_back(agent_list[neighbor.id]);
+                std::cout<<" Role: Mission"<<std::endl;
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
                     std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Mission"<<std::endl;
@@ -48,6 +49,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Potential)
             {
                 potential_neighbors.push_back(agent_list[neighbor.id]);
+                std::cout<<" Role: Potential"<<std::endl;
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
                     std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Potential"<<std::endl;
@@ -55,6 +57,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             }
             else if (neighbor_agent.role_type == agent_util::AgentRoleType::Idle)
             {
+                std::cout<<" Role: Idle"<<std::endl;
                 idle_neighbors.push_back(agent_list[neighbor.id]);
                 if (id_ == DEBUG_ID_TO_LOG)
                 {
@@ -79,9 +82,9 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             std::cout<<"Self role: Mission"<<std::endl;
         }
         // Only interacts with mission neihbors
-        summed_velocity += alignmentTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
-                        + attractionTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
-                        + repulsionTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission]);
+        summed_velocity += alignmentTerm(self_agent, mission_neighbors, VAT_params_[self_agent.role_type])
+                        + attractionTerm(self_agent, mission_neighbors, VAT_params_[self_agent.role_type])
+                        + repulsionTerm(self_agent, mission_neighbors, VAT_params_[self_agent.role_type]);
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Potential)
     {
@@ -114,11 +117,13 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             //Should not happen by definition.
         }
 
-        summed_velocity += attractionTerm(self_agent, two_best_mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission]);
+        summed_velocity += attractionTerm(self_agent, two_best_mission_neighbors, VAT_params_[self_agent.role_type])
+                        += alignmentTerm(self_agent, two_best_mission_neighbors, VAT_params_[self_agent.role_type]);
         
         // Repulsed by potential and idle neighbors.
-        summed_velocity += repulsionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
-                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle]);
+        summed_velocity += repulsionTerm(self_agent, potential_neighbors, VAT_params_[self_agent.role_type])
+                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[self_agent.role_type])
+                         + repulsionTerm(self_agent, mission_neighbors, VAT_params_[self_agent.role_type]);
     }
     else if (self_agent.role_type == agent_util::AgentRoleType::Idle)
     {
@@ -127,14 +132,14 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             std::cout<<"Self role: Idle"<<std::endl;
         }
         // Interacts normally with idle neighbors.
-        summed_velocity += alignmentTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])
-                         + attractionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])
-                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle]);
+        summed_velocity += alignmentTerm(self_agent, idle_neighbors, VAT_params_[self_agent.role_type])
+                         + attractionTerm(self_agent, idle_neighbors, VAT_params_[self_agent.role_type])
+                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[self_agent.role_type]);
 
         // Interacts normally with potential neighbors.
-        summed_velocity += alignmentTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
-                         + attractionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
-                         + repulsionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential]);
+        summed_velocity += alignmentTerm(self_agent, potential_neighbors, VAT_params_[self_agent.role_type])
+                         + attractionTerm(self_agent, potential_neighbors, VAT_params_[self_agent.role_type])
+                         + repulsionTerm(self_agent, potential_neighbors, VAT_params_[self_agent.role_type]);
     }
     else
     {

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
@@ -2,6 +2,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include <utility>
 
+#define DEBUG_ID_TO_LOG 100
+
 VATController::VATController(const VATController::ControllerOptions_t& options): id_(options.id), 
                                                                                  VAT_params_(std::move(options.VAT_params)),
                                                                                  desired_fixed_altitude_(options.desired_fixed_altitude),
@@ -21,37 +23,42 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     std::vector<std::shared_ptr<const agent_util::AgentState_t>> mission_neighbors;
     std::vector<std::shared_ptr<const agent_util::AgentState_t>> potential_neighbors;
     std::vector<std::shared_ptr<const agent_util::AgentState_t>> idle_neighbors;
-    for (auto neighbor : agent_list)
+
+    std::cout<<"Current agent ID: " << id_ << std::endl;
+    for (auto neighbor : self_agent.neighbors)
     {
-        if (neighbor->id != id_)
+        if (neighbor.id != id_)
         {
-            if(neighbor->role_type == agent_util::AgentRoleType::Undefined)
+            const agent_util::AgentState_t& neighbor_agent = *agent_list[neighbor.id];
+
+            std::cout<<"Nieghbor Id: " << neighbor.id << ". Link quality: "<< neighbor.link_quality <<std::endl;
+            if( neighbor_agent.role_type == agent_util::AgentRoleType::Undefined)
             {
                 //Should not happen by definition of the Undefined role
-                std::cout << "Agent of id " << id_ << " has an neighbor of id" << neighbor->id << " that has an undefined role. It shouldn't happen."<<std::endl;
+                std::cout << "Agent of id " << id_ << " has an neighbor of id" << neighbor.id << " that has an undefined role. It shouldn't happen."<<std::endl;
             }
-            else if (neighbor->role_type == agent_util::AgentRoleType::Mission)
+            else if (neighbor_agent.role_type == agent_util::AgentRoleType::Mission)
             {
-                mission_neighbors.push_back(neighbor);
-                if (id_ == 7)
+                mission_neighbors.push_back(agent_list[neighbor.id]);
+                if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Mission"<<std::endl;
+                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Mission"<<std::endl;
                 }
             }
-            else if (neighbor->role_type == agent_util::AgentRoleType::Potential)
+            else if (neighbor_agent.role_type == agent_util::AgentRoleType::Potential)
             {
-                potential_neighbors.push_back(neighbor);
-                if (id_ == 7)
+                potential_neighbors.push_back(agent_list[neighbor.id]);
+                if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Potential"<<std::endl;
+                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Potential"<<std::endl;
                 }
             }
-            else if (neighbor->role_type == agent_util::AgentRoleType::Idle)
+            else if (neighbor_agent.role_type == agent_util::AgentRoleType::Idle)
             {
-                idle_neighbors.push_back(neighbor);
-                if (id_ == 7)
+                idle_neighbors.push_back(agent_list[neighbor.id]);
+                if (id_ == DEBUG_ID_TO_LOG)
                 {
-                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Idle"<<std::endl;
+                    std::cout<<"Has neighbor "<< neighbor.id <<" as " <<" Idle"<<std::endl;
                 }
             }
         }
@@ -60,14 +67,14 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     if (self_agent.role_type == agent_util::AgentRoleType::Undefined)
     {
         // TODO: Find behavior for undefined roles
-        if (id_ == 7)
+        if (id_ == DEBUG_ID_TO_LOG)
         {
             std::cout<<"Self role: Undefined"<<std::endl;
         }
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Mission)
     {     
-        if (id_ == 7)
+        if (id_ == DEBUG_ID_TO_LOG)
         {
             std::cout<<"Self role: Mission"<<std::endl;
         }
@@ -78,7 +85,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Potential)
     {
-        if (id_ == 7)
+        if (id_ == DEBUG_ID_TO_LOG)
         {
             std::cout<<"Self role: Potential"<<std::endl;
         }
@@ -115,7 +122,7 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     }
     else if (self_agent.role_type == agent_util::AgentRoleType::Idle)
     {
-        if (id_ == 7)
+        if (id_ == DEBUG_ID_TO_LOG)
         {
             std::cout<<"Self role: Idle"<<std::endl;
         }

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
@@ -1,52 +1,122 @@
 #include "vat_controller.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include <utility>
 
 VATController::VATController(const VATController::ControllerOptions_t& options): id_(options.id), 
-                                                                                 VAT_params_idle_(options.VAT_params_idle),
-                                                                                 VAT_params_mission_(options.VAT_params_mission),
+                                                                                 VAT_params_(std::move(options.VAT_params)),
                                                                                  desired_fixed_altitude_(options.desired_fixed_altitude),
                                                                                  secondary_objective_(options.secondary_objective) {}
 
-dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const std::vector<cuboid::obstacle_t>& obstacles)
+dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector<std::shared_ptr<const agent_util::AgentState_t>>& agent_list, const std::vector<cuboid::obstacle_t>& obstacles)
 {
     dancers_msgs::msg::VelocityHeading velocity_heading;
-    VAT_params_t *role_params;
-    if (self_agent.role_type == agent_util::AgentRoleType::Idle)
+    Eigen::Vector3d summed_velocity = Eigen::Vector3d::Zero();
+
+    const agent_util::AgentState_t& self_agent = *agent_list[id_];
+
+    // The id of agent should match the id expected from the controller.
+    assert(id_ == self_agent.id);
+
+    // Create the list of neighbors based on role
+    std::vector<std::shared_ptr<const agent_util::AgentState_t>> mission_neighbors;
+    std::vector<std::shared_ptr<const agent_util::AgentState_t>> potential_neighbors;
+    std::vector<std::shared_ptr<const agent_util::AgentState_t>> idle_neighbors;
+    for (auto neighbor : agent_list)
     {
-        role_params = &VAT_params_idle_;
+        if (neighbor->id != id_)
+        {
+            if(neighbor->role_type == agent_util::AgentRoleType::Undefined)
+            {
+                //Should not happen by definition of the Undefined role
+                std::cout << "Agent of id " << id_ << " has an neighbor of id" << neighbor->id << " that has an undefined role. It shouldn't happen."<<std::endl;
+            }
+            else if (neighbor->role_type == agent_util::AgentRoleType::Mission)
+            {
+                mission_neighbors.push_back(neighbor);
+            }
+            else if (neighbor->role_type == agent_util::AgentRoleType::Potential)
+            {
+                potential_neighbors.push_back(neighbor);
+            }
+            else if (neighbor->role_type == agent_util::AgentRoleType::Idle)
+            {
+                idle_neighbors.push_back(neighbor);
+            }
+        }
     }
-    else if (self_agent.role_type == agent_util::AgentRoleType::Mission)
+
+    if (self_agent.role_type == agent_util::AgentRoleType::Undefined)
     {
-        role_params = &VAT_params_mission_;
+        // TODO: Find behavior for undefined roles
+    }
+    else if(self_agent.role_type == agent_util::AgentRoleType::Mission)
+    {     
+        // Only interacts with mission neihbors
+        summed_velocity += alignmentTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
+                        + attractionTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
+                        + repulsionTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission]);
+    }
+    else if(self_agent.role_type == agent_util::AgentRoleType::Potential)
+    {
+        // Attracted to at most the two best (based on linked quality) mission neighbor
+        std::vector<std::shared_ptr<const agent_util::AgentState_t>> two_best_mission_neighbors;
+        if (mission_neighbors.size()==1)
+        {
+            two_best_mission_neighbors.push_back(mission_neighbors[0]);
+        }
+        else if (mission_neighbors.size() <= 2)
+        {
+            two_best_mission_neighbors.push_back(mission_neighbors[0]);
+            two_best_mission_neighbors.push_back(mission_neighbors[1]);
+        }
+        else
+        {
+            //Should not happen by definition.
+        }
+
+        summed_velocity += attractionTerm(self_agent, two_best_mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission]);
+        
+        // Repulsed by potential and idle neighbors.
+        summed_velocity += repulsionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
+                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle]);
+    }
+    else if (self_agent.role_type == agent_util::AgentRoleType::Idle)
+    {
+        // Interacts normally with idle neighbors.
+        summed_velocity += alignmentTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])
+                         + attractionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])
+                         + repulsionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle]);
+
+        // Interacts normally with potential neighbors.
+        summed_velocity += alignmentTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
+                         + attractionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential])
+                         + repulsionTerm(self_agent, potential_neighbors, VAT_params_[agent_util::AgentRoleType::Potential]);
     }
     else
     {
-        // Should not happen
-        std::cout<<"Tried to access the parameters of a role that doesn't exist."<<std::endl;
+        std::cout<<"Error: Agent has an undefined role. The role as a casted int value of "<< self_agent.role_type << ". Returning a velocity of 0."<<std::endl;
         return velocity_heading;
     }
 
-    Eigen::Vector3d summed_velocity = Eigen::Vector3d::Zero();;
-
-    summed_velocity = shillTerm(self_agent, obstacles, role_params)
-                    + alignmentTerm(self_agent, neighbors, role_params)
-                    + attractionTerm(self_agent, neighbors, role_params)
-                    + repulsionTerm(self_agent, neighbors, role_params);
+    // Obstacles avoidance
+    summed_velocity += shillTerm(self_agent, obstacles, VAT_params_[self_agent.role_type]);
 
     // Verify if the agent has a secondary objective.
     if (secondary_objective_.has_value())
     {
-        summed_velocity += secondaryObjective(self_agent, secondary_objective_.value(), role_params);
+        summed_velocity += secondaryObjective(self_agent, secondary_objective_.value(), VAT_params_[self_agent.role_type]);
     }
 
-    if (summed_velocity.norm() > role_params->v_max)
+    // Limit speed if too high.
+    if (summed_velocity.norm() > VAT_params_[self_agent.role_type].v_max)
     {
-        summed_velocity = role_params->v_max * summed_velocity.normalized();
+        summed_velocity = VAT_params_[self_agent.role_type].v_max * summed_velocity.normalized();
     }
 
     velocity_heading.velocity.x = summed_velocity[0];
     velocity_heading.velocity.y = summed_velocity[1];
 
+    // Altitude controller if defined.
     if (desired_fixed_altitude_.has_value())
     {
         // Proportional controller with deadband
@@ -66,112 +136,94 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(const agent
         velocity_heading.velocity.z = summed_velocity[2];
     }
 
-
-    
-    
     return velocity_heading;
 }
 
-Eigen::Vector3d VATController::alignmentTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params)
+Eigen::Vector3d VATController::alignmentTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params)
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
     
-    if(role_params)
+    for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
     {
-        for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
-        {
-            const double distance = (self_agent.position - neighbor->position).norm();
-            const double velDiffNorm = (self_agent.velocity - neighbor->velocity).norm();
+        const double distance = (self_agent.position - neighbor->position).norm();
+        const double velDiffNorm = (self_agent.velocity - neighbor->velocity).norm();
 
-            double v_frictmax = std::max((double)role_params->v_frict, sigmoidLin(distance - role_params->r_0_frict, role_params->a_frict, role_params->p_frict));
-            if (velDiffNorm > v_frictmax)
-            {
-                result += role_params->C_frict * (velDiffNorm - v_frictmax) * (neighbor->velocity - self_agent.velocity) / velDiffNorm;
-            }
+        double v_frictmax = std::max((double)role_params.v_frict, sigmoidLin(distance - role_params.r_0_frict, role_params.a_frict, role_params.p_frict));
+        if (velDiffNorm > v_frictmax)
+        {
+            result += role_params.C_frict * (velDiffNorm - v_frictmax) * (neighbor->velocity - self_agent.velocity) / velDiffNorm;
         }
     }
 
     return result;
 }
 
-Eigen::Vector3d VATController::attractionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params)
+Eigen::Vector3d VATController::attractionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params)
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
 
-    if(role_params)
+    for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
     {
-        for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
-        {
-            const Eigen::Vector3d relative_position = self_agent.position  - neighbor->position;
-            const double distance = relative_position.norm();
+        const Eigen::Vector3d relative_position = self_agent.position  - neighbor->position;
+        const double distance = relative_position.norm();
 
-            if (distance > role_params->r_0_att)
-            {
-                result += role_params->p_att * (role_params->r_0_att - distance) * (relative_position) / distance;
-            }
+        if (distance > role_params.r_0_att)
+        {
+            result += role_params.p_att * (role_params.r_0_att - distance) * (relative_position) / distance;
         }
     }
     return result;   
 }
 
-Eigen::Vector3d VATController::repulsionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params)
+Eigen::Vector3d VATController::repulsionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params)
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
 
-    if(role_params)
+    for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
     {
-        for (std::shared_ptr<const agent_util::AgentState_t> neighbor: neighbors)
+        const Eigen::Vector3d relative_position = self_agent.position  - neighbor->position;
+        const double distance = relative_position.norm();
+        if (distance < role_params.r_0_rep && distance > 0.0)
         {
-            const Eigen::Vector3d relative_position = self_agent.position  - neighbor->position;
-            const double distance = relative_position.norm();
-            if (distance < role_params->r_0_rep && distance > 0.0)
-            {
-                result += role_params->p_rep * (role_params->r_0_rep - distance) * (relative_position) / distance;
-            }
+            result += role_params.p_rep * (role_params.r_0_rep - distance) * (relative_position) / distance;
         }
     }
 
     return result;  
 }
 
-Eigen::Vector3d VATController::shillTerm(const agent_util::AgentState_t& self_agent, const std::vector<cuboid::obstacle_t>& obstacles, const VATController::VAT_params_t* role_params)
+Eigen::Vector3d VATController::shillTerm(const agent_util::AgentState_t& self_agent, const std::vector<cuboid::obstacle_t>& obstacles, const VATController::VAT_params_t& role_params)
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
 
-    if(role_params)
+    for (const cuboid::obstacle_t& obstacle : obstacles)
     {
-        for (const cuboid::obstacle_t& obstacle : obstacles)
-        {
-            Eigen::Vector3d shill_agent_position = cuboid::get_nearest_point_from_obstacle(self_agent.position, obstacle);
-            const Eigen::Vector3d relative_shill_position = shill_agent_position - self_agent.position;
+        Eigen::Vector3d shill_agent_position = cuboid::get_nearest_point_from_obstacle(self_agent.position, obstacle);
+        const Eigen::Vector3d relative_shill_position = shill_agent_position - self_agent.position;
 
-            Eigen::Vector3d shill_agent_velocity = role_params->v_shill * - relative_shill_position.normalized();
-            const double velDiffNorm = (self_agent.velocity - shill_agent_velocity).norm();
-            const double v_shillmax = sigmoidLin(relative_shill_position.norm() - role_params->r_0_shill, role_params->a_shill, role_params->p_shill);
-            if (velDiffNorm > v_shillmax)
-            {
-                result += -(velDiffNorm - v_shillmax) * (self_agent.velocity - shill_agent_velocity) / velDiffNorm;
-            }
+        Eigen::Vector3d shill_agent_velocity = role_params.v_shill * - relative_shill_position.normalized();
+        const double velDiffNorm = (self_agent.velocity - shill_agent_velocity).norm();
+        const double v_shillmax = sigmoidLin(relative_shill_position.norm() - role_params.r_0_shill, role_params.a_shill, role_params.p_shill);
+        if (velDiffNorm > v_shillmax)
+        {
+            result += -(velDiffNorm - v_shillmax) * (self_agent.velocity - shill_agent_velocity) / velDiffNorm;
         }
     }
 
     return result;   
 }
 
-Eigen::Vector3d VATController::secondaryObjective(const agent_util::AgentState_t& self_agent, const Eigen::Vector3d& goal, const VATController::VAT_params_t* role_params)
+Eigen::Vector3d VATController::secondaryObjective(const agent_util::AgentState_t& self_agent, const Eigen::Vector3d& goal, const VATController::VAT_params_t& role_params)
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
     
-    if(role_params)
+    Eigen::Vector3d relative_position = self_agent.position - goal;
+
+    result += role_params.v_flock * -(relative_position);
+
+    if (result.norm() > role_params.v_max)
     {
-        Eigen::Vector3d relative_position = self_agent.position - goal;
-
-        result += role_params->v_flock * -(relative_position);
-
-        if (result.norm() > role_params->v_max)
-        {
-            result = role_params->v_max * result.normalized();
-        }
+        result = role_params.v_max * result.normalized();
     }
 
     return result;

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.cpp
@@ -33,14 +33,26 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
             else if (neighbor->role_type == agent_util::AgentRoleType::Mission)
             {
                 mission_neighbors.push_back(neighbor);
+                if (id_ == 7)
+                {
+                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Mission"<<std::endl;
+                }
             }
             else if (neighbor->role_type == agent_util::AgentRoleType::Potential)
             {
                 potential_neighbors.push_back(neighbor);
+                if (id_ == 7)
+                {
+                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Potential"<<std::endl;
+                }
             }
             else if (neighbor->role_type == agent_util::AgentRoleType::Idle)
             {
                 idle_neighbors.push_back(neighbor);
+                if (id_ == 7)
+                {
+                    std::cout<<"Has neighbor "<< neighbor->id <<" as " <<" Idle"<<std::endl;
+                }
             }
         }
     }
@@ -48,9 +60,17 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     if (self_agent.role_type == agent_util::AgentRoleType::Undefined)
     {
         // TODO: Find behavior for undefined roles
+        if (id_ == 7)
+        {
+            std::cout<<"Self role: Undefined"<<std::endl;
+        }
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Mission)
     {     
+        if (id_ == 7)
+        {
+            std::cout<<"Self role: Mission"<<std::endl;
+        }
         // Only interacts with mission neihbors
         summed_velocity += alignmentTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
                         + attractionTerm(self_agent, mission_neighbors, VAT_params_[agent_util::AgentRoleType::Mission])
@@ -58,16 +78,29 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     }
     else if(self_agent.role_type == agent_util::AgentRoleType::Potential)
     {
-        // Attracted to at most the two best (based on linked quality) mission neighbor
+        if (id_ == 7)
+        {
+            std::cout<<"Self role: Potential"<<std::endl;
+        }
+        // Attracted to at most the two best (based on linked quality) mission neighbor and repulsed by other mission
         std::vector<std::shared_ptr<const agent_util::AgentState_t>> two_best_mission_neighbors;
+        std::vector<std::shared_ptr<const agent_util::AgentState_t>> other_mission_neighbors;
         if (mission_neighbors.size()==1)
         {
             two_best_mission_neighbors.push_back(mission_neighbors[0]);
+            std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
         }
-        else if (mission_neighbors.size() <= 2)
+        else if (mission_neighbors.size() >= 2)
         {
             two_best_mission_neighbors.push_back(mission_neighbors[0]);
             two_best_mission_neighbors.push_back(mission_neighbors[1]);
+            std::cout<<"Has neighbor "<< mission_neighbors[0]->id <<" as " <<" best Mission"<<std::endl;
+            std::cout<<"Has neighbor "<< mission_neighbors[1]->id <<" as " <<" best Mission"<<std::endl;
+
+            for (int index = 2; index < mission_neighbors.size(); index++)
+            {
+                other_mission_neighbors.push_back(mission_neighbors[index]);
+            }
         }
         else
         {
@@ -82,6 +115,10 @@ dancers_msgs::msg::VelocityHeading VATController::getVelocityHeading(std::vector
     }
     else if (self_agent.role_type == agent_util::AgentRoleType::Idle)
     {
+        if (id_ == 7)
+        {
+            std::cout<<"Self role: Idle"<<std::endl;
+        }
         // Interacts normally with idle neighbors.
         summed_velocity += alignmentTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])
                          + attractionTerm(self_agent, idle_neighbors, VAT_params_[agent_util::AgentRoleType::Idle])

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.hpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.hpp
@@ -56,14 +56,14 @@ class VATController
             int id;
 
             /**
-             * @brief VAT parameters of the idle role.
+             * @brief VAT parameters for all roles.
              */
-            VAT_params_t VAT_params_idle;
-
-            /**
-             * @brief VAT parameters of the mission role.
-             */
-            VAT_params_t VAT_params_mission;
+            std::map<agent_util::AgentRoleType, VAT_params_t> VAT_params = {
+                {agent_util::AgentRoleType::Undefined, {}},
+                {agent_util::AgentRoleType::Mission, {}},
+                {agent_util::AgentRoleType::Potential, {}},
+                {agent_util::AgentRoleType::Idle, {}}
+            };
 
             /**
              * @brief Optional fixed altitude that, if set, will overide the flocking behavior to control the altitude of the drones within a 1m deadband of the set altitude.
@@ -80,12 +80,11 @@ class VATController
 
         /**
          * @brief Computes the velocity command of the agent based on the VAT controller.
-         * @param self_agent Agent containinig its position, velocities and neighbors information.
-         * @param neighbors List of all neighbors.
+         * @param agent_list List of all agents states and their neighbors.
          * @param obstacles Array of 3D obstacles in the environement.
          * @return Return the computed velocity command as a ROS message. 
          */
-        dancers_msgs::msg::VelocityHeading getVelocityHeading(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const std::vector<cuboid::obstacle_t>& obstacles);
+        dancers_msgs::msg::VelocityHeading getVelocityHeading(std::vector<std::shared_ptr<const agent_util::AgentState_t>>& agent_list, const std::vector<cuboid::obstacle_t>& obstacles);
     
         /**
          * @brief Constructor of the VAT controller that initialize the internal states of the controller.
@@ -100,19 +99,14 @@ class VATController
         int id_;
 
         /**
-         * @brief VAT parameters for the idle role.
+         * @brief VAT parameter dictionnaries that contains the parameter for each role of neighbors.
          */
-        VAT_params_t VAT_params_idle_;
-
-        /**
-         * @brief VAT parameters for the mission role.
-         */
-        VAT_params_t VAT_params_mission_;
-        
-        /**
-         * @brief VAT parameters for the idle neighbors.
-         */
-        VAT_params_t idle_params_;
+        std::map<agent_util::AgentRoleType, VAT_params_t> VAT_params_ = {
+            {agent_util::AgentRoleType::Undefined, {}},
+            {agent_util::AgentRoleType::Mission, {}},
+            {agent_util::AgentRoleType::Potential, {}},
+            {agent_util::AgentRoleType::Idle, {}}
+        };
 
         /**
          * @brief Objective point in space that attracts the agent, if defined.
@@ -139,7 +133,7 @@ class VATController
          * @param params Flocking parameters to use.
          * @return Velocity command of the behavior.
          */
-        Eigen::Vector3d alignmentTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params);
+        Eigen::Vector3d alignmentTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params);
 
         /**
          * @brief Flocking behavior that attracts the agent towards its neighbors of a given neighbor type.
@@ -148,7 +142,7 @@ class VATController
          * @param params Flocking parameters to use.
          * @return Velocity command of the behavior.
          */
-        Eigen::Vector3d attractionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params);
+        Eigen::Vector3d attractionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params);
 
         /**
          * @brief Flocking behavior that repulse the agent from its neighbors of a given neighbor type.
@@ -157,7 +151,7 @@ class VATController
          * @param params Flocking parameters to use.
          * @return Velocity command of the behavior.
          */
-        Eigen::Vector3d repulsionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t* role_params);
+        Eigen::Vector3d repulsionTerm(const agent_util::AgentState_t& self_agent, std::vector<std::shared_ptr<const agent_util::AgentState_t>>& neighbors, const VATController::VAT_params_t& role_params);
 
         /**
          * @brief Flocking behavior that pushes the heading of the agent perpendicaly from the nearest obstacle surfaces.
@@ -166,7 +160,7 @@ class VATController
          * @param params Flocking parameters to use.
          * @return Velocity command of the behavior.
          */
-        Eigen::Vector3d shillTerm(const agent_util::AgentState_t& self_agent, const std::vector<cuboid::obstacle_t>& obstacles, const VATController::VAT_params_t* role_params);
+        Eigen::Vector3d shillTerm(const agent_util::AgentState_t& self_agent, const std::vector<cuboid::obstacle_t>& obstacles, const VATController::VAT_params_t& role_params);
         
         /**
          * @brief Flocking behavior that attracts the agent towards a goal position.
@@ -175,7 +169,7 @@ class VATController
          * @param params Flocking parameters to use.
          * @return Velocity command of the behavior.
          */
-        Eigen::Vector3d secondaryObjective(const agent_util::AgentState_t& self_agent, const Eigen::Vector3d& goal, const VATController::VAT_params_t* role_params);
+        Eigen::Vector3d secondaryObjective(const agent_util::AgentState_t& self_agent, const Eigen::Vector3d& goal, const VATController::VAT_params_t& role_params);
 
 
         /**

--- a/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.hpp
+++ b/src/physics_simulators/MiniDancers/flocking_controller/src/vat_controller.hpp
@@ -29,6 +29,7 @@ class VATController
         {
             float v_flock;
             float v_max;
+            float v_sec_max;
             float a_frict;
             float p_frict;
             float r_0_frict;
@@ -42,6 +43,9 @@ class VATController
             float p_shill;
             float r_0_shill;
             float v_shill;
+
+            float expected_deconnexion_distance;
+            bool use_deconnexion_distance_instead_of_p_att = false;
         };
 
         /**

--- a/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/command_algorithms/VAT_flocking_controller.hpp
+++ b/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/command_algorithms/VAT_flocking_controller.hpp
@@ -27,8 +27,9 @@ Eigen::Vector3d alignment_term(std::vector<agent_t *> uavs, int which_agent, VAT
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
     MultirotorModel::State agent_state = uavs[which_agent]->uav_system.getState();
-    for (int neighbor_id : uavs[which_agent]->neighbors)
+    for (NeighborInfo_t& neighbor: uavs[which_agent]->neighbors)
     {
+        int neighbor_id = neighbor.id;
         if (neighbor_id != which_agent)
         {
             MultirotorModel::State neighbor_state = uavs[neighbor_id]->uav_system.getState();
@@ -49,8 +50,9 @@ Eigen::Vector3d attraction_term(std::vector<agent_t *> uavs, int which_agent, VA
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
     MultirotorModel::State agent_state = uavs[which_agent]->uav_system.getState();
-    for (int neighbor_id : uavs[which_agent]->neighbors)
+    for (NeighborInfo_t& neighbor: uavs[which_agent]->neighbors)
     {
+        int neighbor_id = neighbor.id;
         if (neighbor_id != which_agent)
         {
             MultirotorModel::State neighbor_state = uavs[neighbor_id]->uav_system.getState();
@@ -69,8 +71,9 @@ Eigen::Vector3d repulsion_term(std::vector<agent_t *> uavs, int which_agent, VAT
 {
     Eigen::Vector3d result = Eigen::Vector3d::Zero();
     MultirotorModel::State agent_state = uavs[which_agent]->uav_system.getState();
-    for (int neighbor_id : uavs[which_agent]->neighbors)
+    for (NeighborInfo_t& neighbor: uavs[which_agent]->neighbors)
     {
+        int neighbor_id = neighbor.id;
         if (neighbor_id != which_agent)
         {
             MultirotorModel::State neighbor_state = uavs[neighbor_id]->uav_system.getState();

--- a/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/util/agent_util.hpp
+++ b/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/util/agent_util.hpp
@@ -4,6 +4,26 @@
 #include <vector>
 
 /**
+ * @brief Structure containing the information about the neighbors.
+ */
+struct NeighborInfo_t
+{
+    int id;
+    double link_quality;
+};
+
+/**
+ * @brief Possible roles that an agent can have. This role influence their flocking behaviors.
+ */
+enum AgentRoleType
+{
+    Undefined = 0,
+    Mission,
+    Potential,
+    Idle
+};
+
+/**
  * @struct The struct holding information for a connected UAV agent
  * 
  * It holds the UavSystem object, its id, the list(s) of its neighbors and its objectives (targets)
@@ -12,7 +32,8 @@ struct agent_t
 {
     mrs_multirotor_simulator::UavSystem uav_system;
     int id;
-    std::vector<int> neighbors;
+    AgentRoleType role;
+    std::vector<NeighborInfo_t> neighbors;
     std::vector<int> neighbors_mission;
     std::vector<int> neighbors_potential;
     std::vector<int> neighbors_routing;

--- a/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/util/flocking_util.hpp
+++ b/src/physics_simulators/MiniDancers/mini_dancers/include/mini_dancers/util/flocking_util.hpp
@@ -18,13 +18,3 @@ double SigmoidLin(const double r, const double a, const double p)
         return std::sqrt(2 * a * r - std::pow(a, 2) / std::pow(p, 2));
     }
 }
-
-
-/**
- * @enum Indicates the role of an agent
- */
-enum AgentRoleType
-{
-    Idle=0,
-    Mission
-};

--- a/src/protobuf_msgs/protobuf/ordered_neighbors.proto
+++ b/src/protobuf_msgs/protobuf/ordered_neighbors.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
-
 package ordered_neighbors_proto;
 
 message OrderedNeighborsList {
     repeated OrderedNeighbors ordered_neighbors = 1;
 }
 
+/* This message assumes that the role known by agent X about its neighbor Y, is coherent with the real role of Y. */
 message OrderedNeighbors {
     enum Role{
         UNDEFINED = 0;


### PR DESCRIPTION
- Adapted the VAT controller in the flocking_controller to run a dynamic role-based flocking with tow new roles: Undefined and Potential. 
- The Undefined role are agent with no neighbors and there is no behaviors defined for them so far. 
- The Potential role is attracted towards to up most two Mission neighbors. They are selected based on the best network quality links. 
- Added parameters for all defined roles.
- Added logging in the flocking_controller.